### PR TITLE
The ending tag should be on the previous line.

### DIFF
--- a/src/pages/TimerPage.vue
+++ b/src/pages/TimerPage.vue
@@ -75,8 +75,7 @@
             The Pomodoro Technique was developed by Francesco Cirillo. It functions in 30
             minute blocks with 25 minutes allotted for work and 5 minutes for a break.
             Learn more
-            <a href="https://todoist.com/productivity-methods/pomodoro-technique">here</a
-            >.
+            <a href="https://todoist.com/productivity-methods/pomodoro-technique">here</a>.
           </p>
         </q-card-section>
       </q-card>


### PR DESCRIPTION
This is an egregious fallacy that you must fix at once. This is entirely erroneous, Lucas. I am quite disappointed in you.





/s
